### PR TITLE
Adding Reset for QueryHandle class

### DIFF
--- a/inc/wing/QueryHandle.h
+++ b/inc/wing/QueryHandle.h
@@ -35,6 +35,11 @@ public:
     auto operator = (QueryHandle&&) -> QueryHandle& = default;  ///< Can move assign
 
     /**
+     * Resets QueryHandle, freeing results and clearing m_query_parts and m_bind_params
+     */
+    auto Reset() -> void;
+
+    /**
      * @param on_complete The on complete function handle for this query.
      */
     auto SetOnCompleteHandler(

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -17,6 +17,7 @@ Query::~Query()
 {
     if(m_query_handle)
     {
+        m_query_handle->Reset();
         QueryPool& query_pool = m_query_handle->m_query_pool;
         query_pool.returnQuery(std::move(m_query_handle));
     }

--- a/src/QueryHandle.cpp
+++ b/src/QueryHandle.cpp
@@ -59,8 +59,12 @@ QueryHandle::QueryHandle(
 
 QueryHandle::~QueryHandle()
 {
-    freeResult();
+    Reset();
     mysql_close(&m_mysql);
+}
+
+auto QueryHandle::Reset() -> void {
+    freeResult();
     m_query_parts.clear();
     m_bind_params.clear();
 }


### PR DESCRIPTION
Reset is called by the Query object when adding QueryHandle back into the pool.

  modified:   inc/wing/QueryHandle.h
  modified:   src/Query.cpp
  modified:   src/QueryHandle.cpp