### PR TITLE
Adding Reset for QueryHandle class

### DIFF
--- a/inc/wing/QueryHandle.h
+++ b/inc/wing/QueryHandle.h
@@ -36,6 +36,11 @@ public:
     auto operator = (QueryHandle&&) -> QueryHandle& = default;  ///< Can move assign
 
     /**
+     * Resets QueryHandle, freeing results and clearing m_query_parts and m_bind_params
+     */
+    auto Reset() -> void;
+
+    /**
      * @param on_complete The on complete function handle for this query.
      */
     auto SetOnCompleteHandler(

--- a/src/QueryHandle.cpp
+++ b/src/QueryHandle.cpp
@@ -52,8 +52,16 @@ QueryHandle::QueryHandle(
 
 QueryHandle::~QueryHandle()
 {
-    freeResult();
+    Reset();
     mysql_close(&m_mysql);
+}
+
+auto QueryHandle::Reset() -> void {
+    freeResult();
+    m_statement = Statement();
+    m_query_status = QueryStatus::BUILDING;
+    m_user_data = nullptr;
+    m_had_error = false;
 }
 
 auto QueryHandle::SetOnCompleteHandler(

--- a/src/QueryPool.cpp
+++ b/src/QueryPool.cpp
@@ -97,6 +97,7 @@ auto QueryPool::returnQuery(
     }
 
     {
+        query_handle->Reset();
         std::lock_guard<std::mutex> guard(m_lock);
         m_queries.emplace_back(std::move(query_handle));
     }


### PR DESCRIPTION
Reset is called by the Query object when adding QueryHandle
back into the pool.

  modified:   inc/wing/QueryHandle.h
  modified:   src/Query.cpp
  modified:   src/QueryHandle.cpp